### PR TITLE
fix: update request headers for DuckDuckGo Email Protection

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import requests
 import pyperclip
 from dotenv import load_dotenv
 import os
+import platform
 
 # Load environment variables
 load_dotenv()
@@ -9,13 +10,39 @@ load_dotenv()
 # Get the DuckDuckGo Access Token from environment variable
 ACCESS_TOKEN = os.getenv('DUCKDUCKGO_ACCESS_TOKEN')
 
+USER_AGENTS = {
+    "Darwin": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/27.0 "
+        "Safari/605.1.15 Ddg/27.0"
+    ),
+    "Windows": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 "
+        "Safari/537.36"
+    ),
+}
+
 
 def generate_temp_email():
+    if not ACCESS_TOKEN:
+        raise RuntimeError(
+            "DUCKDUCKGO_ACCESS_TOKEN is not set in the .env file"
+        )
+
+    user_agent = USER_AGENTS.get(platform.system())
+    if not user_agent:
+        raise RuntimeError("Only macOS and Windows are supported")
+
     url = "https://quack.duckduckgo.com/api/email/addresses"
     headers = {
-        "Authorization": f"Bearer {ACCESS_TOKEN}"
+        "Accept": "*/*",
+        "Authorization": f"Bearer {ACCESS_TOKEN}",
+        "Origin": "https://duckduckgo.com",
+        "Referer": "https://duckduckgo.com/",
+        "User-Agent": user_agent,
     }
-    response = requests.post(url, headers=headers)
+    response = requests.post(url, headers=headers, timeout=30)
     if response.status_code == 201:
         address = response.json()['address']
         email = address + "@duck.com"


### PR DESCRIPTION
## Summary

DuckDuckGo Email Protection now rejects requests that only include the Authorization header with HTTP 403.

This PR updates the request headers to match the browser request and selects the appropriate DuckDuckGo Browser User-Agent for macOS and Windows. The endpoint URL and authorization flow remain unchanged.

## Changes

- Add `Accept`, `Origin`, and `Referer` headers
- Select a platform-specific User-Agent for macOS and Windows
- Add a 30-second request timeout
- Add clear errors for missing tokens and unsupported platforms

## Testing

- [x] Verified on macOS
- [x] Verified on Windows
- [ ] Linux / WSL not supported

Both macOS and Windows successfully generated a DuckDuckGo email address and copied it to the clipboard.